### PR TITLE
feat: reorder fields in entity edit views (#440)

### DIFF
--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -115,7 +115,7 @@ class TempEntityClass(models.Model):
     img_last_checked = models.DateTimeField(
         blank=True,
         null=True,
-        verbose_name="geprüft am",
+        verbose_name="Bild geprüft am",
         help_text="Datum an dem die Bild-URL eingetragen wurde.",
     )
 

--- a/normdata/tests.py
+++ b/normdata/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from pylobid.pylobid import PyLobidPerson
 
+from apis_core.apis_metainfo.models import Uri
 from normdata.utils import (
     get_gender_from_pylobid,
     get_or_create_org_from_wikidata,
@@ -66,3 +67,12 @@ class NormdataTestCase(TestCase):
             "https://www.geonames.org/2516696/marisma-de-hinojos.html", "place"
         )
         self.assertTrue(entity.kind)
+
+    def test_007_check_for_wiengeschichte(self):
+        wiengeschichte_uri = (
+            "https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid=36065"
+        )
+        test_uri = "https://d-nb.info/gnd/129325074"
+        self.assertFalse(Uri.objects.filter(uri=wiengeschichte_uri))
+        import_from_normdata(test_uri, "person")
+        self.assertTrue(Uri.objects.get(uri=wiengeschichte_uri))

--- a/normdata/utils.py
+++ b/normdata/utils.py
@@ -136,6 +136,15 @@ def get_or_create_place_from_wikidata(uri):
                         )
                 except IntegrityError:
                     pass
+                if wd_entity.wien_geschichte_wiki:
+                    try:
+                        Uri.objects.create(
+                            uri=get_normalized_uri(wd_entity.wien_geschichte_wiki),
+                            domain="wiengeschichtewiki",
+                            entity=entity,
+                        )
+                    except IntegrityError:
+                        pass
                 try:
                     if wd_entity.geonames_uri:
                         Uri.objects.create(
@@ -224,6 +233,15 @@ def get_or_create_person_from_wikidata(uri):
                     Uri.objects.create(
                         uri=get_normalized_uri(wd_entity.gnd_uri),
                         domain="gnd",
+                        entity=entity,
+                    )
+                except IntegrityError:
+                    pass
+            if wd_entity.wien_geschichte_wiki:
+                try:
+                    Uri.objects.create(
+                        uri=get_normalized_uri(wd_entity.wien_geschichte_wiki),
+                        domain="wiengeschichtewiki",
                         entity=entity,
                     )
                 except IntegrityError:
@@ -367,6 +385,15 @@ def get_or_create_org_from_wikidata(uri):
                     Uri.objects.create(
                         uri=get_normalized_uri(wd_entity.gnd_uri),
                         domain="gnd",
+                        entity=entity,
+                    )
+                except IntegrityError:
+                    pass
+            if wd_entity.wien_geschichte_wiki:
+                try:
+                    Uri.objects.create(
+                        uri=get_normalized_uri(wd_entity.wien_geschichte_wiki),
+                        domain="wiengeschichtewiki",
                         entity=entity,
                     )
                 except IntegrityError:

--- a/notebooks/issue__116-wiengeschichteuris.ipynb
+++ b/notebooks/issue__116-wiengeschichteuris.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc8d5f53-f450-4c73-afdd-eb7e0672742b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 2026-06-03\n",
+    "from apis_core.apis_metainfo.models import Uri\n",
+    "from django.core.exceptions import ObjectDoesNotExist\n",
+    "from csae_pyutils import gsheet_to_df\n",
+    "from apis_core.apis_metainfo.models import TempEntityClass\n",
+    "from apis_core.utils import get_object_from_pk_or_uri\n",
+    "\n",
+    "from tqdm import tqdm\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c4cbbc34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "domain = \"wiengeschichtewiki\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "768d3c59",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "200\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = gsheet_to_df(\"1dXjEymTuoaXKMyX9OMyuXE7snP9xQzZdNdG4ZFVfbs8\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2e3f4b2d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pmb_id</th>\n",
+       "      <th>wiengeschichte_id</th>\n",
+       "      <th>wikidata_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>100058</td>\n",
+       "      <td>361612</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q20752213</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>100060</td>\n",
+       "      <td>37942</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q19194784</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>100065</td>\n",
+       "      <td>17793</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q60818670</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>100068</td>\n",
+       "      <td>8893</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q1598331</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>100074</td>\n",
+       "      <td>40288</td>\n",
+       "      <td>http://www.wikidata.org/entity/Q60818680</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   pmb_id  wiengeschichte_id                               wikidata_id\n",
+       "0  100058             361612  http://www.wikidata.org/entity/Q20752213\n",
+       "1  100060              37942  http://www.wikidata.org/entity/Q19194784\n",
+       "2  100065              17793  http://www.wikidata.org/entity/Q60818670\n",
+       "3  100068               8893   http://www.wikidata.org/entity/Q1598331\n",
+       "4  100074              40288  http://www.wikidata.org/entity/Q60818680"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0bd425b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "1696it [01:03, 14.18it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "154517 https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid=8791 duplicate key value violates unique constraint \"idx_2976579_uri\"\n",
+      "DETAIL:  Key (uri)=(https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid=8791) already exists.\n",
+      "\n",
+      "154517 https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid=10660 duplicate key value violates unique constraint \"idx_2976579_uri\"\n",
+      "DETAIL:  Key (uri)=(https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid=10660) already exists.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "1712it [01:04, 11.86it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "155232 https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid=8791 duplicate key value violates unique constraint \"idx_2976579_uri\"\n",
+      "DETAIL:  Key (uri)=(https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid=8791) already exists.\n",
+      "\n",
+      "155232 https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid=10660 duplicate key value violates unique constraint \"idx_2976579_uri\"\n",
+      "DETAIL:  Key (uri)=(https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid=10660) already exists.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "3929it [02:45, 23.67it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i, row in tqdm(df.iterrows()):\n",
+    "    try:\n",
+    "        entity = TempEntityClass.objects.get(id=row[\"pmb_id\"])\n",
+    "    except ObjectDoesNotExist:\n",
+    "        entity = get_object_from_pk_or_uri(row[\"pmb_id\"])\n",
+    "    wr_uri = f\"https://www.geschichtewiki.wien.gv.at/Special:URIResolver/?curid={row['wiengeschichte_id']}\"\n",
+    "    try:\n",
+    "        uri = Uri.objects.get_or_create(uri=wr_uri, domain=domain, entity=entity)\n",
+    "    except Exception as e:\n",
+    "        print(row[\"pmb_id\"], wr_uri, e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99063b38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wr_uri"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bccb529-3e66-42ff-9842-b2a5d4ede131",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Django Shell-Plus",
+   "language": "python",
+   "name": "django_extensions"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pmb/settings.py
+++ b/pmb/settings.py
@@ -205,7 +205,7 @@ APIS_ENTITIES = {
     "Place": {
         "merge": True,
         "search": ["name"],
-        "form_order": ["name", "kind", "lat", "lng", "status", "collection"],
+        "form_order": ["name", "kind", "lat", "lng", "img_url", "collection", "status", "img_last_checked"],
         "table_fields": ["name"],
         "additional_cols": ["id", "lat", "lng", "part_of"],
         "list_filters": [
@@ -227,8 +227,12 @@ APIS_ENTITIES = {
             "start_date_written",
             "end_date_written",
             "profession",
-            "status",
+            "title",
+            "gender",
+            "img_url",
             "collection",
+            "status",
+            "img_last_checked",
         ],
         "table_fields": [
             "name",
@@ -257,8 +261,10 @@ APIS_ENTITIES = {
             "start_date_written",
             "end_date_written",
             "kind",
-            "status",
+            "img_url",
             "collection",
+            "status",
+            "img_last_checked",
         ],
         "additional_cols": [
             "id",
@@ -277,6 +283,16 @@ APIS_ENTITIES = {
     "Work": {
         "merge": True,
         "search": ["name"],
+        "form_order": [
+            "name",
+            "start_date_written",
+            "end_date_written",
+            "kind",
+            "img_url",
+            "collection",
+            "status",
+            "img_last_checked",
+        ],
         "additional_cols": [
             "id",
             "kind",
@@ -293,6 +309,16 @@ APIS_ENTITIES = {
     "Event": {
         "merge": True,
         "search": ["name"],
+        "form_order": [
+            "name",
+            "start_date_written",
+            "end_date_written",
+            "kind",
+            "img_url",
+            "collection",
+            "status",
+            "img_last_checked",
+        ],
         "additional_cols": [
             "id",
         ],

--- a/pmb/settings.py
+++ b/pmb/settings.py
@@ -205,7 +205,7 @@ APIS_ENTITIES = {
     "Place": {
         "merge": True,
         "search": ["name"],
-        "form_order": ["name", "kind", "lat", "lng", "img_url", "collection", "status", "img_last_checked"],
+        "form_order": ["name", "kind", "lat", "lng", "img_url", "img_last_checked", "collection", "status"],
         "table_fields": ["name"],
         "additional_cols": ["id", "lat", "lng", "part_of"],
         "list_filters": [
@@ -230,9 +230,9 @@ APIS_ENTITIES = {
             "title",
             "gender",
             "img_url",
+            "img_last_checked",
             "collection",
             "status",
-            "img_last_checked",
         ],
         "table_fields": [
             "name",
@@ -262,9 +262,9 @@ APIS_ENTITIES = {
             "end_date_written",
             "kind",
             "img_url",
+            "img_last_checked",
             "collection",
             "status",
-            "img_last_checked",
         ],
         "additional_cols": [
             "id",
@@ -289,9 +289,9 @@ APIS_ENTITIES = {
             "end_date_written",
             "kind",
             "img_url",
+            "img_last_checked",
             "collection",
             "status",
-            "img_last_checked",
         ],
         "additional_cols": [
             "id",
@@ -315,9 +315,9 @@ APIS_ENTITIES = {
             "end_date_written",
             "kind",
             "img_url",
+            "img_last_checked",
             "collection",
             "status",
-            "img_last_checked",
         ],
         "additional_cols": [
             "id",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "acdh-geonames-utils>=0.5.0",
     "acdh-id-reconciler>0.7.1",
     "acdh-tei-pyutils>=2.3.0",
-    "acdh-wikidata-pyutils>=3.0",
+    "acdh-wikidata-pyutils>=3.1",
     "apis-override-select2js>=0.2.1",
     "coverage>=7.11.0",
     "csae-pyutils>=0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "acdh-wikidata-pyutils"
-version = "3.0"
+version = "3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "acdh-arche-assets" },
@@ -98,9 +98,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wikidata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/ae/51a3a8a480a867abea21357e126cd9ab165a946ddbfaaaa27261607e32ca/acdh_wikidata_pyutils-3.0.tar.gz", hash = "sha256:cb9f0e21cd7bfbc58f511e7eec39f9ed1d33d7193731dc4746ac7b359eef3432", size = 4140, upload-time = "2025-09-03T07:49:31.491Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/d3/7b33b8da15ad455620b016664eaee0a5bdfbc068d9bebe44c202d6f6be8d/acdh_wikidata_pyutils-3.1.tar.gz", hash = "sha256:156c6adeca663d132dc46f80f844acee84e646f6a53a83560cdddd9cee202a8d", size = 4371, upload-time = "2026-06-06T12:28:43.991Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/1e/5da60971441e4205ef791a3d825a7bfd9f2465a8a298ad721daa9b84cf03/acdh_wikidata_pyutils-3.0-py3-none-any.whl", hash = "sha256:43e6da6015e7b6efeb6f0f1a5a0fe0a3baa2f4e3fd642a9452c71c7219ac883d", size = 4846, upload-time = "2025-09-03T07:49:30.664Z" },
+    { url = "https://files.pythonhosted.org/packages/43/09/221c4908161e1142138b099db4d8da92a17e4ffff1f067eb7f957cf28a8e/acdh_wikidata_pyutils-3.1-py3-none-any.whl", hash = "sha256:66bd1b4e55c0b1f219e37e1d6fc357418c73c3688b6991b629004a26706e6749", size = 5073, upload-time = "2026-06-06T12:28:43.196Z" },
 ]
 
 [[package]]
@@ -1464,7 +1464,7 @@ requires-dist = [
     { name = "acdh-geonames-utils", specifier = ">=0.5.0" },
     { name = "acdh-id-reconciler", specifier = ">0.7.1" },
     { name = "acdh-tei-pyutils", specifier = ">=2.3.0" },
-    { name = "acdh-wikidata-pyutils", specifier = ">=3.0" },
+    { name = "acdh-wikidata-pyutils", specifier = ">=3.1" },
     { name = "apis-override-select2js", specifier = ">=0.2.1" },
     { name = "coverage", specifier = ">=7.11.0" },
     { name = "csae-pyutils", specifier = ">=0.2" },
@@ -2151,9 +2151,9 @@ wheels = [
 
 [[package]]
 name = "wikidata"
-version = "0.8.1"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/61/b8c6f83737e02dd4098a33fca84a517d6583a1bf2755ac9e1adb4ec5c8b6/Wikidata-0.8.1.tar.gz", hash = "sha256:2d44aa538ca3bcbc36ddf9f88957f6e487407d96e7a8a7bcee39da472b90f28b", size = 26112, upload-time = "2024-07-07T03:46:11.162Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/da/59fe9524010a37eafd06673f87783a7440a8cf2606ac7b214dae1ba5fa39/wikidata-0.9.0.tar.gz", hash = "sha256:059e4e9574aa2a03e4327d28df8c0cc661db2826a75900cda0142bdc01b4bb7f", size = 26350, upload-time = "2025-10-31T06:52:34.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/04/000f4b830f0a14a56d2fe1fea43e67b7f7ea561e7cca8d9b57f48157ec4c/Wikidata-0.8.1-py3-none-any.whl", hash = "sha256:2f0e2b8b77150cb374a729f3b4fbadbfedfbd091e1f25d08f5403cb0d8306cda", size = 29118, upload-time = "2024-07-07T03:46:08.609Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f4/101b2fa3b57641f52a7d83c103d5bb18899122299d456fc2d8783e351148/wikidata-0.9.0-py3-none-any.whl", hash = "sha256:3e908cecf9fab177393034ccac759fbdb79b9389b32b4f1a2cc556fac3a25895", size = 44066, upload-time = "2025-10-31T06:52:32.862Z" },
 ]


### PR DESCRIPTION
## Summary

- Moves `title` and `gender` directly after `profession` in the Person edit form
- Adds `img_url` and `img_last_checked` (Bild URL / geprüft am) to the end of `form_order` for all entities
- Adds `form_order` for Work and Event (previously missing) so field ordering is now consistent across all five entity types

## Consistent tail order (all entities)
`img_url → collection → status → img_last_checked`

## Test plan
- [ ] Person edit form: title/gender appear after profession; img_url and img_last_checked visible at the end
- [ ] Place, Institution, Work, Event edit forms: img_url and img_last_checked visible at the end
- [ ] No form crashes (form_order must list all non-excluded, non-MetaInfo fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)