### PR TITLE
feat: Schnittmengen – Überschneidungen zwischen Domains finden (#455)…

### DIFF
--- a/apis_core/apis_entities/domain_crossing_views.py
+++ b/apis_core/apis_entities/domain_crossing_views.py
@@ -1,0 +1,278 @@
+import django_tables2 as tables
+from django.conf import settings
+from django.db.models import Count
+from django.views.generic import TemplateView
+from django_tables2 import RequestConfig
+from django_tables2.export import TableExport
+
+from apis_core.apis_entities.models import (
+    Event,
+    Institution,
+    Person,
+    Place,
+    Work,
+)
+
+# Entitätstyp -> (Modell, Anzeigename, Icon)
+ENTITY_TYPES = {
+    "person": (Person, "Personen", "bi bi-people"),
+    "place": (Place, "Orte", "bi bi-map"),
+    "work": (Work, "Werke", "bi bi-book"),
+    "event": (Event, "Ereignisse", "bi bi-calendar3"),
+    "institution": (Institution, "Institutionen", "bi bi-building-gear"),
+}
+
+# Modus -> Anzeigename
+MODES = {
+    "intersection": "Schnittmenge",
+    "union": "Vereinigung",
+    "difference": "Differenz",
+}
+
+# Modus -> Erklärtext (als Tooltip angezeigt)
+MODE_DESCRIPTIONS = {
+    "intersection": (
+        "Entitäten, die in allen gewählten Domains vorkommen. "
+        "Beispiel: Personen, die sowohl in »schnitzler-briefe« als auch "
+        "in »gnd« vorhanden sind."
+    ),
+    "union": (
+        "Entitäten, die in mindestens einer der gewählten Domains vorkommen. "
+        "Beispiel: alle Personen, die in »schnitzler-briefe« oder »gnd« "
+        "(oder in beiden) vorkommen."
+    ),
+    "difference": (
+        "Entitäten, die in der Basis-Domain vorkommen, aber in keiner der "
+        "ausgeschlossenen Domains. Beispiel: Personen in »schnitzler-briefe«, "
+        "die keinen »gnd«-Eintrag haben."
+    ),
+}
+
+DEFAULT_TYPE = "person"
+DEFAULT_MODE = "intersection"
+
+# Reihenfolge & Farben der Domains aus den Projekt-Einstellungen
+DOMAIN_LABELS = [entry[1] for entry in settings.DOMAIN_MAPPING]
+DOMAIN_COLORS = {entry[1]: entry[2] for entry in settings.DOMAIN_MAPPING}
+
+
+# Gender-Filter: Wert -> Anzeigename (nur für Personen)
+GENDER_OPTIONS = [
+    ("female", "weiblich"),
+    ("male", "männlich"),
+    ("other", "anderes oder nicht ausgezeichnet"),
+]
+
+
+class DomainCrossingTable(tables.Table):
+    """Generische Tabelle, die für jeden Entitätstyp funktioniert."""
+
+    id = tables.Column(verbose_name="ID", orderable=True, linkify=True)
+    name = tables.Column(
+        verbose_name="Name", orderable=True, linkify=True, default="ohne Name"
+    )
+    start_date_written = tables.Column(verbose_name="von", orderable=True)
+    end_date_written = tables.Column(verbose_name="bis", orderable=True)
+
+    class Meta:
+        attrs = {"class": "table table-responsive table-hover"}
+        sequence = ("id", "name", "start_date_written", "end_date_written")
+
+
+class PersonCrossingTable(DomainCrossingTable):
+    """Tabelle für Personen – zeigt zusätzlich den Vornamen."""
+
+    first_name = tables.Column(verbose_name="Vorname", orderable=True)
+
+    class Meta(DomainCrossingTable.Meta):
+        sequence = (
+            "id",
+            "name",
+            "first_name",
+            "start_date_written",
+            "end_date_written",
+        )
+
+
+class DomainCrossingView(TemplateView):
+    """Findet Überschneidungen zwischen Daten-Domains (Schnittmenge,
+    Vereinigung, Differenz) für einen wählbaren Entitätstyp."""
+
+    template_name = "apis_entities/domain_crossing.html"
+    export_name = "schnittmengen"
+
+    def get(self, request, *args, **kwargs):
+        context = self.get_context_data(**kwargs)
+        export_format = request.GET.get("_export", None)
+        if TableExport.is_valid_format(export_format):
+            exporter = TableExport(export_format, context["table"])
+            return exporter.response(f"{self.export_name}.{export_format}")
+        return self.render_to_response(context)
+
+    def _querystring(self, **changes):
+        """Aktuellen Querystring übernehmen, einzelne Parameter ändern und
+        die Seitennummer zurücksetzen."""
+        params = self.request.GET.copy()
+        params.pop("page", None)
+        for key, value in changes.items():
+            if value is None or value == []:
+                params.pop(key, None)
+            elif isinstance(value, list):
+                params.setlist(key, value)
+            else:
+                params[key] = value
+        return f"?{params.urlencode()}"
+
+    def _build_queryset(self, model, mode, selected, base):
+        qs = model.objects.all()
+        if mode == "union":
+            if not selected:
+                return qs.none()
+            qs = qs.filter(uri__domain__in=selected)
+        elif mode == "difference":
+            if base not in DOMAIN_LABELS:
+                return qs.none()
+            qs = qs.filter(uri__domain=base)
+            excluded = [d for d in selected if d != base]
+            if excluded:
+                qs = qs.exclude(uri__domain__in=excluded)
+        else:  # intersection
+            if not selected:
+                return qs.none()
+            for domain in selected:
+                qs = qs.filter(uri__domain=domain)
+        return qs.distinct()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        request = self.request
+
+        etype = request.GET.get("type", DEFAULT_TYPE)
+        if etype not in ENTITY_TYPES:
+            etype = DEFAULT_TYPE
+        mode = request.GET.get("mode", DEFAULT_MODE)
+        if mode not in MODES:
+            mode = DEFAULT_MODE
+        selected = [d for d in request.GET.getlist("d") if d in DOMAIN_LABELS]
+        base = request.GET.get("base")
+        if base not in DOMAIN_LABELS:
+            base = None
+        gender = request.GET.get("gender")
+        if gender not in dict(GENDER_OPTIONS):
+            gender = None
+
+        model, verbose_name, _icon = ENTITY_TYPES[etype]
+
+        # Trefferzahl je Domain für diesen Entitätstyp
+        counts = dict(
+            model.objects.filter(uri__domain__in=DOMAIN_LABELS)
+            .values_list("uri__domain")
+            .annotate(c=Count("pk", distinct=True))
+        )
+
+        # Entitätstyp-Buttons
+        entity_buttons = []
+        for key, (_m, label, icon) in ENTITY_TYPES.items():
+            entity_buttons.append(
+                {
+                    "key": key,
+                    "label": label,
+                    "icon": icon,
+                    "active": key == etype,
+                    "href": self._querystring(type=key),
+                }
+            )
+
+        # Modus-Buttons
+        mode_buttons = [
+            {
+                "key": key,
+                "label": label,
+                "description": MODE_DESCRIPTIONS[key],
+                "active": key == mode,
+                "href": self._querystring(mode=key),
+            }
+            for key, label in MODES.items()
+        ]
+
+        # Domain-Buttons (nur Domains, die für diesen Typ vorkommen)
+        domain_buttons = []
+        base_buttons = []
+        for domain in DOMAIN_LABELS:
+            count = counts.get(domain, 0)
+            if not count:
+                continue
+            color = DOMAIN_COLORS.get(domain, settings.DEFAULT_COLOR)
+            is_selected = domain in selected
+            toggled = (
+                [d for d in selected if d != domain]
+                if is_selected
+                else selected + [domain]
+            )
+            domain_buttons.append(
+                {
+                    "label": domain,
+                    "color": color,
+                    "count": count,
+                    "selected": is_selected,
+                    "href": self._querystring(d=toggled),
+                }
+            )
+            base_buttons.append(
+                {
+                    "label": domain,
+                    "color": color,
+                    "count": count,
+                    "selected": domain == base,
+                    "href": self._querystring(base=None if domain == base else domain),
+                }
+            )
+
+        # Gender-Buttons und -Filter (nur für Personen)
+        gender_buttons = []
+        if etype == "person":
+            for value, label in GENDER_OPTIONS:
+                gender_buttons.append(
+                    {
+                        "value": value,
+                        "label": label,
+                        "active": value == gender,
+                        "href": self._querystring(
+                            gender=None if value == gender else value
+                        ),
+                    }
+                )
+
+        queryset = self._build_queryset(model, mode, selected, base)
+        if etype == "person" and gender:
+            if gender == "other":
+                queryset = queryset.exclude(gender__in=["female", "male"])
+            else:
+                queryset = queryset.filter(gender=gender)
+        queryset = queryset.order_by("name")
+
+        table_class = PersonCrossingTable if etype == "person" else DomainCrossingTable
+        table = table_class(queryset)
+        RequestConfig(request, paginate={"per_page": 25}).configure(table)
+
+        context.update(
+            {
+                "table": table,
+                "entity": etype,
+                "verbose_name": verbose_name,
+                "mode": mode,
+                "mode_label": MODES[mode],
+                "selected": selected,
+                "base": base,
+                "gender": gender,
+                "entity_buttons": entity_buttons,
+                "mode_buttons": mode_buttons,
+                "domain_buttons": domain_buttons,
+                "base_buttons": base_buttons,
+                "gender_buttons": gender_buttons,
+                "total": table.paginator.count,
+                "enable_merge": False,
+                "app_name": "apis_entities",
+            }
+        )
+        return context

--- a/apis_core/apis_entities/templates/apis_entities/domain_crossing.html
+++ b/apis_core/apis_entities/templates/apis_entities/domain_crossing.html
@@ -1,0 +1,114 @@
+{% extends "base.html" %}
+{% load static %}
+{% load django_tables2 %}
+{% block title %}Schnittmengen{% endblock %}
+{% block content %}
+{% include "partials/entity_styles.html" %}
+
+<div class="container pt-4">
+    <h1 class="display-1 text-center apis-{{ entity }}">
+        <i class="bi bi-intersect"></i> Schnittmengen
+    </h1>
+    <p class="text-center text-muted">
+        Überschneidungen zwischen Daten-Domains für einen Entitätstyp finden.
+    </p>
+
+    <div class="row pt-2">
+        <div class="col-12 text-center mb-3">
+            <h2 class="h5">Entitätstyp</h2>
+            <div class="btn-group flex-wrap" role="group" aria-label="Entitätstyp">
+                {% for b in entity_buttons %}
+                <a href="{{ b.href }}"
+                   class="btn {% if b.active %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                    <i class="{{ b.icon }}"></i> {{ b.label }}
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+
+        <div class="col-12 text-center mb-3">
+            <h2 class="h5">Modus</h2>
+            <div class="btn-group flex-wrap" role="group" aria-label="Modus">
+                {% for b in mode_buttons %}
+                <a href="{{ b.href }}"
+                   class="btn {% if b.active %}btn-secondary{% else %}btn-outline-secondary{% endif %}"
+                   data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="{{ b.description }}">
+                    {{ b.label }}
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+
+        {% if gender_buttons %}
+        <div class="col-12 text-center mb-3">
+            <h2 class="h5">Gender</h2>
+            <div class="btn-group flex-wrap" role="group" aria-label="Gender">
+                {% for b in gender_buttons %}
+                <a href="{{ b.href }}"
+                   class="btn {% if b.active %}btn-secondary{% else %}btn-outline-secondary{% endif %}">
+                    {{ b.label }}
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="col-12 text-center mb-3">
+            {% if mode == "difference" %}
+            <h2 class="h5">Basis-Domain <small class="text-muted">(enthalten in)</small></h2>
+            <div class="mb-3">
+                {% for b in base_buttons %}
+                <a href="{{ b.href }}"
+                   class="btn btn-sm m-1 {% if b.selected %}text-white{% else %}btn-outline-dark{% endif %}"
+                   {% if b.selected %}style="background-color:{{ b.color }};border-color:{{ b.color }}"{% endif %}>
+                    {{ b.label }} <span class="badge bg-light text-dark">{{ b.count }}</span>
+                </a>
+                {% endfor %}
+            </div>
+            <h2 class="h5">Ausgeschlossene Domains <small class="text-muted">(nicht enthalten in)</small></h2>
+            {% else %}
+            <h2 class="h5">Domains</h2>
+            {% endif %}
+            <div>
+                {% for b in domain_buttons %}
+                <a href="{{ b.href }}"
+                   class="btn btn-sm m-1 {% if b.selected %}text-white{% else %}btn-outline-dark{% endif %}"
+                   {% if b.selected %}style="background-color:{{ b.color }};border-color:{{ b.color }}"{% endif %}>
+                    {{ b.label }} <span class="badge bg-light text-dark">{{ b.count }}</span>
+                </a>
+                {% empty %}
+                <p class="text-muted">Keine Domains für diesen Entitätstyp vorhanden.</p>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    <hr>
+
+    <div class="row">
+        <div class="col-12" id="results">
+            <h2 class="text-center">{{ total }} {{ verbose_name }}</h2>
+            {% if selected or base %}
+            <div>
+                {% include 'browsing/partials/table.html' %}
+                {% include 'browsing/partials/pagination.html' %}
+                <div class="float-end">
+                    {% include "browsing/partials/download_menu.html" %}
+                </div>
+            </div>
+            {% else %}
+            <p class="text-center text-muted">
+                Bitte mindestens eine Domain auswählen.
+            </p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+        new bootstrap.Tooltip(el);
+    });
+</script>
+{% endblock %}

--- a/apis_core/apis_entities/tests.py
+++ b/apis_core/apis_entities/tests.py
@@ -568,3 +568,183 @@ class EntitiesTestCase(TestCase):
 
         with self.assertRaises(StartDateAfterEndDateError):
             relation_instance.save()
+
+
+class DomainCrossingTestCase(TestCase):
+    """Tests für die Schnittmengen-Ansicht (Domains kreuzen)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Jede angelegte Entität erhält automatisch eine "pmb"-URI.
+        cls.p_both = Person.objects.create(
+            name="Both", first_name="Anna", gender="female"
+        )
+        cls.p_gnd = Person.objects.create(name="GndOnly", gender="male")
+        cls.p_wiki = Person.objects.create(name="WikiOnly", gender="third gender")
+        cls.place_gnd = Place.objects.create(name="PlaceGnd")
+
+        Uri.objects.create(
+            uri="https://d-nb.info/gnd/both", domain="gnd", entity=cls.p_both
+        )
+        Uri.objects.create(
+            uri="https://www.wikidata.org/entity/both",
+            domain="wikidata",
+            entity=cls.p_both,
+        )
+        Uri.objects.create(
+            uri="https://d-nb.info/gnd/gndonly", domain="gnd", entity=cls.p_gnd
+        )
+        Uri.objects.create(
+            uri="https://www.wikidata.org/entity/wikionly",
+            domain="wikidata",
+            entity=cls.p_wiki,
+        )
+        Uri.objects.create(
+            uri="https://d-nb.info/gnd/place", domain="gnd", entity=cls.place_gnd
+        )
+
+    def setUp(self):
+        self.url = reverse("apis:apis_entities:domain_crossing")
+
+    def _names(self, response):
+        return {row.record.name for row in response.context["table"].rows}
+
+    def test_intersection(self):
+        response = client.get(
+            f"{self.url}?type=person&mode=intersection&d=gnd&d=wikidata"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), {"Both"})
+
+    def test_union(self):
+        response = client.get(f"{self.url}?type=person&mode=union&d=gnd&d=wikidata")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self._names(response), {"Both", "GndOnly", "WikiOnly"}
+        )
+
+    def test_difference(self):
+        response = client.get(
+            f"{self.url}?type=person&mode=difference&base=gnd&d=wikidata"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), {"GndOnly"})
+
+    def test_entity_type_switch(self):
+        response = client.get(f"{self.url}?type=place&mode=intersection&d=gnd")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), {"PlaceGnd"})
+
+    def test_no_domain_selected_returns_empty(self):
+        response = client.get(f"{self.url}?type=person&mode=intersection")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["total"], 0)
+
+    def test_invalid_type_falls_back_to_person(self):
+        response = client.get(f"{self.url}?type=nonsense&mode=union&d=gnd")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["entity"], "person")
+        self.assertEqual(self._names(response), {"Both", "GndOnly"})
+
+    def test_gender_female(self):
+        response = client.get(
+            f"{self.url}?type=person&mode=union&d=gnd&d=wikidata&gender=female"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), {"Both"})
+
+    def test_gender_male(self):
+        response = client.get(
+            f"{self.url}?type=person&mode=union&d=gnd&d=wikidata&gender=male"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), {"GndOnly"})
+
+    def test_gender_other(self):
+        # "anderes oder nicht ausgezeichnet" umfasst u.a. "third gender"
+        response = client.get(
+            f"{self.url}?type=person&mode=union&d=gnd&d=wikidata&gender=other"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), {"WikiOnly"})
+
+    def test_gender_ignored_for_non_person(self):
+        response = client.get(
+            f"{self.url}?type=place&mode=intersection&d=gnd&gender=female"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), {"PlaceGnd"})
+        self.assertEqual(response.context["gender_buttons"], [])
+
+    def test_first_name_column_for_person(self):
+        response = client.get(f"{self.url}?type=person&mode=union&d=gnd")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("first_name", response.context["table"].columns.names())
+
+    def test_union_without_domains_is_empty(self):
+        response = client.get(f"{self.url}?type=person&mode=union")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["total"], 0)
+
+    def test_difference_without_base_is_empty(self):
+        response = client.get(f"{self.url}?type=person&mode=difference&d=gnd")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["total"], 0)
+
+    def test_difference_base_only_without_exclusion(self):
+        response = client.get(f"{self.url}?type=person&mode=difference&base=gnd")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self._names(response), {"Both", "GndOnly"})
+
+    def test_invalid_gender_is_ignored(self):
+        response = client.get(
+            f"{self.url}?type=person&mode=union&d=gnd&gender=nonsense"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["gender"])
+        self.assertEqual(self._names(response), {"Both", "GndOnly"})
+
+    def test_default_page_without_params(self):
+        response = client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["entity"], "person")
+        self.assertEqual(response.context["mode"], "intersection")
+        self.assertEqual(response.context["total"], 0)
+
+    def test_invalid_mode_falls_back_to_intersection(self):
+        response = client.get(f"{self.url}?type=person&mode=nonsense&d=gnd&d=wikidata")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["mode"], "intersection")
+        self.assertEqual(self._names(response), {"Both"})
+
+    def test_mode_tooltips_rendered(self):
+        response = client.get(f"{self.url}?type=person&mode=intersection&d=gnd")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-bs-toggle="tooltip"')
+        self.assertContains(response, "in allen gewählten Domains vorkommen")
+
+    def test_export_csv(self):
+        response = client.get(
+            f"{self.url}?type=person&mode=union&d=gnd&d=wikidata&_export=csv"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/csv", response["Content-Type"])
+        self.assertIn("schnittmengen.csv", response["Content-Disposition"])
+        content = response.getvalue().decode("utf-8")
+        self.assertIn("Both", content)
+        self.assertNotIn("<a", content)
+
+    def test_export_json(self):
+        response = client.get(
+            f"{self.url}?type=person&mode=union&d=gnd&d=wikidata&_export=json"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("schnittmengen.json", response["Content-Disposition"])
+        self.assertIn("Both", response.getvalue().decode("utf-8"))
+
+    def test_invalid_export_format_renders_page(self):
+        response = client.get(
+            f"{self.url}?type=person&mode=union&d=gnd&_export=nonsense"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "apis_entities/domain_crossing.html")

--- a/apis_core/apis_entities/urls.py
+++ b/apis_core/apis_entities/urls.py
@@ -8,10 +8,16 @@ from .list_view_person import PersonListView
 from .list_view_place import PlaceListView
 from .list_view_work import WorkListView
 from .arc_views import get_arcs_data, ArcsView
+from .domain_crossing_views import DomainCrossingView
 
 app_name = "apis_entities"
 
 urlpatterns = [
+    path(
+        "domain-crossing",
+        DomainCrossingView.as_view(),
+        name="domain_crossing",
+    ),
     path(
         "arcs-data",
         get_arcs_data,

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -67,6 +67,12 @@
                             </li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
+                                <a class="dropdown-item" href="{% url 'apis:apis_entities:domain_crossing' %}">
+                                    <i class="bi bi-intersect"></i>
+                                    Schnittmengen
+                                </a>
+                            </li>
+                            <li>
                                 <a class="dropdown-item" href="{% url 'apis:apis_metainfo:uri_browse' %}">
                                     <i class="bi bi-link-45deg apis-uri"></i>URIs
                                 </a>


### PR DESCRIPTION
… (#456)

* feat: add domain crossing view to find overlaps between domains (#455)

Neuer Menüpunkt "Schnittmengen" (vorletzter Punkt im Entitäten-Menü): Auswahl von Entitätstyp, Modus (Schnittmenge/Vereinigung/Differenz) und Domains per Buttons; darunter die gefilterte Entitätsliste mit Domain-Badges. Basiert auf Uri.domain und settings.DOMAIN_MAPPING.



* feat: Vorname-Spalte und Gender-Filter in Schnittmengen-Ansicht

- Personenliste zeigt zusätzlich den Vornamen (eigene PersonCrossingTable)
- Domains-Spalte aus der Ergebnisliste entfernt (redundant zur Auswahl)
- Gender-Filter als Buttons nur bei Personen: weiblich / männlich / anderes oder nicht ausgezeichnet (alles außer female/male)



* test: cover edge cases in domain crossing view

Tests für leere Auswahl (Vereinigung/Differenz), Differenz ohne Ausschluss, ungültiges Gender und Default-Seite; defensive _querystring-Verzweigung vereinfacht.



* test: cover invalid mode fallback in domain crossing view



* feat: "ohne Name" if surname is missing

* feat: Tooltips mit Erklärtexten für Schnittmenge/Vereinigung/Differenz

Modus-Buttons erhalten kurze Erklärungen samt Beispiel als Bootstrap-5.3-Tooltips (data-bs-toggle="tooltip"), inkl. Init-Skript.



* feat: Download (CSV/JSON) der Schnittmengen-Ergebnisse

Export via django-tables2 TableExport (?_export=csv|json) mit Download-Menü unter der Ergebnisliste. Link-Spalten auf linkify umgestellt, damit der Export saubere Werte statt HTML enthält.



---------